### PR TITLE
Feat/#69/wine list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1373,7 +1373,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -3148,6 +3147,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",

--- a/src/apis/wine.ts
+++ b/src/apis/wine.ts
@@ -1,0 +1,46 @@
+import { apiFetch } from './fetchClient';
+
+export interface GetWinesParams {
+  limit: number;
+  cursor?: number;
+  type?: 'RED' | 'WHITE' | 'SPARKLING';
+  name?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  rating?: number;
+}
+
+/**
+ * 와인 목록 조회 (fetchClient 활용 버전)
+ */
+export async function getWines(params: GetWinesParams) {
+  const { limit, cursor, type, name, minPrice, maxPrice, rating } = params;
+
+  const searchParams = new URLSearchParams({
+    limit: limit.toString(),
+  });
+
+  // 파라미터가 있을 때만 추가
+  if (cursor) {
+    searchParams.append('cursor', cursor.toString());
+  }
+  if (type) {
+    searchParams.append('type', type);
+  }
+  if (name) {
+    searchParams.append('name', name);
+  }
+  if (minPrice) {
+    searchParams.append('minPrice', minPrice.toString());
+  }
+  if (maxPrice) {
+    searchParams.append('maxPrice', maxPrice.toString());
+  }
+  if (rating) {
+    searchParams.append('rating', rating.toString());
+  }
+
+  // apiFetch가 내부적으로 토큰을 꺼내서 헤더에 넣어줍니다!
+  // /22-1/wines?limit=10...
+  return apiFetch(`/wines?${searchParams.toString()}`);
+}

--- a/src/apis/wine.ts
+++ b/src/apis/wine.ts
@@ -1,18 +1,17 @@
+import type { WineTypeKind } from '@/constants/WineType.constants';
 import { apiFetch } from './fetchClient';
 
 export interface GetWinesParams {
-  limit: number;
-  cursor?: number;
-  type?: 'RED' | 'WHITE' | 'SPARKLING';
-  name?: string;
-  minPrice?: number;
-  maxPrice?: number;
-  rating?: number;
+  limit: number; // 한 번에 가져올 데이터 개수
+  cursor?: number; // 다음 페이지 데이터를 가져오기 위한 시작점
+  type?: WineTypeKind; // 와인 종류
+  name?: string; // 검색창에 입력한 와인 이름
+  minPrice?: number; // 최소 가격 필터
+  maxPrice?: number; // 최대 가격 필터
+  rating?: number; // 평점 필터
 }
 
-/**
- * 와인 목록 조회 (fetchClient 활용 버전)
- */
+/* 서버에 와인 목록 데이터를 요청하는 함수 */
 export async function getWines(params: GetWinesParams) {
   const { limit, cursor, type, name, minPrice, maxPrice, rating } = params;
 
@@ -20,7 +19,7 @@ export async function getWines(params: GetWinesParams) {
     limit: limit.toString(),
   });
 
-  // 파라미터가 있을 때만 추가
+  // 선택적 파라미터 처리 : 값이 존재할 때만 URL에 추가함.
   if (cursor) {
     searchParams.append('cursor', cursor.toString());
   }
@@ -40,7 +39,7 @@ export async function getWines(params: GetWinesParams) {
     searchParams.append('rating', rating.toString());
   }
 
-  // apiFetch가 내부적으로 토큰을 꺼내서 헤더에 넣어줍니다!
-  // /22-1/wines?limit=10...
+  // 최종 완성된 주소
+  // apiFetch 내부에서 로그인 토큰(JWT)을 자동으로 헤더에 담아서 보냄.
   return apiFetch(`/wines?${searchParams.toString()}`);
 }

--- a/src/components/list/WineListCard/index.module.css
+++ b/src/components/list/WineListCard/index.module.css
@@ -30,7 +30,7 @@
 
 /* 정보 영역 */
 .infoContent {
-  padding: 16px 20px 24px;
+  padding-top: 24px;
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/src/components/list/WineListCard/index.tsx
+++ b/src/components/list/WineListCard/index.tsx
@@ -4,31 +4,31 @@ import StarRating from '@/components/common/StarRating';
 
 interface WineListCardProps {
   id: number; // 와인 상세 페이지 이동을 위한 ID
-  imageUrl: string; // 와인 이미지 경로
+  image: string; // 와인 이미지 경로
   name: string; // 와인 이름
-  rating: number; // 평균 별점
+  avgRating: number; // 평균 별점
   reviewCount: number; // 총 리뷰 개수
   type: WineTypeKind; // 와인 타입
   price: number; // 가격
-  latestReview?: {
+  recentReview?: {
     content: string; // 최신 후기 내용
   };
 }
 
 function WineListCard({
   id,
-  imageUrl,
+  image,
   name,
-  rating,
+  avgRating,
   reviewCount,
   type,
   price,
-  latestReview,
+  recentReview,
 }: WineListCardProps) {
   return (
     <article className={styles.cardContainer}>
       <div className={styles.imageWrapper}>
-        <img src={imageUrl} alt={name} className={styles.wineImage} />
+        <img src={image} alt={name} className={styles.wineImage} />
       </div>
 
       <div className={styles.infoContent}>
@@ -37,24 +37,24 @@ function WineListCard({
         <div className={styles.ratingRow}>
           <StarRating
             mode={'displayOnly'}
-            value={rating}
+            value={avgRating}
             count={reviewCount}
             size={'list'}
           />
         </div>
 
         {/* 최신 후기가 있을 때만 렌더링 */}
-        {latestReview && (
+        {recentReview && (
           <div className={styles.latestReviewSection}>
-            {latestReview ? (
+            {recentReview ? (
               // 후기가 있을 때: 라벨 + 내용 모두 노출
               <>
                 <p className={styles.reviewLabel}>최신 후기</p>
-                <p className={styles.reviewText}>{latestReview.content}</p>
+                <p className={styles.reviewText}>{recentReview.content}</p>
               </>
             ) : (
               // 후기가 없을 때: 안내 문구 노출
-              <p className={styles.emptyReviewText}>
+              <p className={styles.reviewText}>
                 아직 후기가 없어요. 첫 후기를 남겨주세요!
               </p>
             )}

--- a/src/components/list/WineListCard/index.tsx
+++ b/src/components/list/WineListCard/index.tsx
@@ -1,6 +1,6 @@
-import type { WineTypeKind } from '@/constants/WineType.constants';
 import styles from './index.module.css';
 import StarRating from '@/components/common/StarRating';
+import { Link } from 'react-router-dom';
 
 interface WineListCardProps {
   id: number; // 와인 상세 페이지 이동을 위한 ID
@@ -8,8 +8,6 @@ interface WineListCardProps {
   name: string; // 와인 이름
   avgRating: number; // 평균 별점
   reviewCount: number; // 총 리뷰 개수
-  type: WineTypeKind; // 와인 타입
-  price: number; // 가격
   recentReview?: {
     content: string; // 최신 후기 내용
   };
@@ -21,47 +19,47 @@ function WineListCard({
   name,
   avgRating,
   reviewCount,
-  type,
-  price,
   recentReview,
 }: WineListCardProps) {
   return (
-    <article className={styles.cardContainer}>
-      <div className={styles.imageWrapper}>
-        <img src={image} alt={name} className={styles.wineImage} />
-      </div>
-
-      <div className={styles.infoContent}>
-        <h3 className={styles.wineName}>{name}</h3>
-
-        <div className={styles.ratingRow}>
-          <StarRating
-            mode={'displayOnly'}
-            value={avgRating}
-            count={reviewCount}
-            size={'list'}
-          />
+    <Link to={`/wines/${id}`} className={styles.cardLink}>
+      <article className={styles.cardContainer}>
+        {/* 와인 사진 */}
+        <div className={styles.imageWrapper}>
+          <img src={image} alt={name} className={styles.wineImage} />
         </div>
 
-        {/* 최신 후기가 있을 때만 렌더링 */}
-        {recentReview && (
-          <div className={styles.latestReviewSection}>
+        <div className={styles.infoContent}>
+          {/* 와인 이름 */}
+          <h3 className={styles.wineName}>{name}</h3>
+
+          {/* 별점 */}
+          <div className={styles.ratingRow}>
+            <StarRating
+              mode={'displayOnly'}
+              value={avgRating}
+              count={reviewCount}
+              size={'list'}
+            />
+          </div>
+
+          {/* 후기 */}
+          {/* 최신 후기가 있을 때만 렌더링 */}
+          <div className={styles.recentReviewSection}>
             {recentReview ? (
-              // 후기가 있을 때: 라벨 + 내용 모두 노출
               <>
                 <p className={styles.reviewLabel}>최신 후기</p>
                 <p className={styles.reviewText}>{recentReview.content}</p>
               </>
             ) : (
-              // 후기가 없을 때: 안내 문구 노출
               <p className={styles.reviewText}>
                 아직 후기가 없어요. 첫 후기를 남겨주세요!
               </p>
             )}
           </div>
-        )}
-      </div>
-    </article>
+        </div>
+      </article>
+    </Link>
   );
 }
 

--- a/src/components/list/WineListGrid/index.module.css
+++ b/src/components/list/WineListGrid/index.module.css
@@ -1,0 +1,26 @@
+.gridContainer {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr); /* 2열 */
+  column-gap: 52px; /* 좌우 간격 */
+  row-gap: 48px; /* 상하 간격 */
+  padding: 20px;
+
+  /* 370px * 2 + 24px = 764px + 여백 */
+  max-width: 800px;
+}
+
+/* 태블릿 */
+@media (max-width: 1080px) {
+  .gridContainer {
+    column-gap: 24px; /* 좌우 간격 */
+    row-gap: 48px; /* 상하 간격 */
+  }
+}
+
+/* 모바일 */
+@media (max-width: 767px) {
+  .gridContainer {
+    grid-template-columns: 1fr; /* 1열 */
+    row-gap: 48px; /* 상하 간격 */
+  }
+}

--- a/src/components/list/WineListGrid/index.tsx
+++ b/src/components/list/WineListGrid/index.tsx
@@ -1,0 +1,38 @@
+import type { WineTypeKind } from '@/constants/WineType.constants';
+import WineListCard from '../WineListCard';
+import styles from './index.module.css';
+
+export interface Wine {
+  id: number;
+  name: string;
+  image: string;
+  avgRating: number;
+  reviewCount: number;
+  type: WineTypeKind;
+  price: number;
+  recentReview?: {
+    content: string;
+  };
+}
+
+interface WineListGridProps {
+  wines: Wine[]; // any 대신 정의한 Wine 타입을 사용
+}
+
+function WineListGrid({ wines }: WineListGridProps) {
+  // 데이터가 없을 때 방어 로직 추가 (나중에 시안대로 수정)
+  if (!wines || wines.length === 0) {
+    return <div className={styles.empty}>등록된 와인이 없습니다. 🍷</div>;
+  }
+
+  return (
+    <section className={styles.gridContainer}>
+      {/* 데이터 배열을 하나씩 순회하며 카드 컴포넌트로 변환함. */}
+      {wines.map((wine) => (
+        <WineListCard key={wine.id} {...wine} /> // {...wine} : 객체의 모든 속성을 카드 Props 이름과 동일하게 전달함.
+      ))}
+    </section>
+  );
+}
+
+export default WineListGrid;

--- a/src/components/list/WineListGrid/index.tsx
+++ b/src/components/list/WineListGrid/index.tsx
@@ -1,5 +1,5 @@
 import type { WineTypeKind } from '@/constants/WineType.constants';
-import WineListCard from '../WineListCard';
+import WineListCard from '@/components/list/WineListCard';
 import styles from './index.module.css';
 
 export interface Wine {

--- a/src/pages/WinesList/index.tsx
+++ b/src/pages/WinesList/index.tsx
@@ -1,24 +1,46 @@
-import WineListCard from '@/components/list/WineListCard';
-
-const MOCK_WINE = {
-  id: 1,
-  name: 'Sentinel Carbernet Sauvignon 2016',
-  imageUrl: '/assets/images/profile-01.jpg',
-  rating: 4.5,
-  reviewCount: 47,
-  type: 'RED' as const,
-  price: 55000,
-  latestReview: {
-    content:
-      '첫 모금에서 느껴지는 진한 블랙베리와 블랙커런트의 깊은 풍미가 인상적이었어요. 입 안을 가득 채우는 묵직한 바디감과 함께, 오미자',
-  },
-};
+import { getWines, type GetWinesParams } from '@/apis/wine';
+import WineListGrid, { type Wine } from '@/components/list/WineListGrid';
+import { useEffect, useState } from 'react';
 
 function WinesList() {
+  // 서버에서 받아온 와인 목록을 저장할 상태(State)
+  const [wines, setWines] = useState<Wine[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 컴포넌트가 처음 나타날 때 데이터를 불러오는 함수 실행
+  useEffect(() => {
+    const fetchWinesData = async () => {
+      try {
+        setIsLoading(true);
+
+        // API 파라미터 설정 (50개만 먼저 가져와보기)
+        const params: GetWinesParams = { limit: 50 };
+        const data = await getWines(params);
+
+        // 서버 응답 객체 안의 'list' 배열만 골라내서 저장
+        setWines(data.list || []);
+      } catch (error) {
+        console.error('와인 목록 로드 실패:', error);
+      } finally {
+        setIsLoading(false); // 성공/실패 상관없이 끝나면 로딩 false
+      }
+    };
+
+    fetchWinesData();
+  }, []);
+
+  // 로딩 중일 때 보여줄 화면
+  if (isLoading) {
+    return (
+      <div style={{ padding: '40px', textAlign: 'center' }}>
+        와인 정보를 불러오고 있어요... 🍷
+      </div>
+    );
+  }
+
   return (
     <div>
-      와인 리스트
-      <WineListCard {...MOCK_WINE} />
+      <WineListGrid wines={wines} />
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #69 

## 📝작업 내용

- 와인 카드에 API 연동하고, 와인 그리드 컴포넌트로 화면에 리스트 렌더링 구현함.
- 와인 카드 클릭 시 상세 페이지로 이동하게 함. 

### 스크린샷 (선택)
<img width="827" height="570" alt="image" src="https://github.com/user-attachments/assets/6083b5f3-3b8f-46f5-ba63-754da321c3ce" />

### 추가한 라이브러리
> 없음.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
