### PR TITLE
Feat/#76/auth validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,14 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "classnames": "^2.5.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-hook-form": "^7.72.0",
         "react-range": "^1.10.0",
         "react-router-dom": "^7.13.1",
+        "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -817,6 +820,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1253,6 +1268,12 @@
       "funding": {
         "url": "https://ko-fi.com/dangreen"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -5488,6 +5509,23 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
+      "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6859,7 +6897,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "classnames": "^2.5.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-hook-form": "^7.72.0",
     "react-range": "^1.10.0",
     "react-router-dom": "^7.13.1",
+    "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { useId, forwardRef } from 'react';
 import type { InputHTMLAttributes } from 'react';
 import styles from './index.module.css';
 import ErrorIcon from '@/assets/icons/ic-error.svg';
@@ -9,52 +9,55 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   errorMessage?: string;
 }
 
-export default function Input({
-  label,
-  status = 'default',
-  errorMessage,
-  id,
-  className,
-  ...props
-}: InputProps) {
-  const uniqueId = useId();
-  const inputId = id || uniqueId;
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    { label, status = 'default', errorMessage, id, className, ...props },
+    ref
+  ) => {
+    const uniqueId = useId();
+    const inputId = id || uniqueId;
 
-  const inputStatusClass =
-    status === 'error' || status === 'modalError' ? styles.inputError : '';
+    const inputStatusClass =
+      status === 'error' || status === 'modalError' ? styles.inputError : '';
 
-  return (
-    <div className={`${styles.wrapper} ${className || ''}`}>
-      {(label || status === 'modalError') && (
-        <div className={styles.labelWrapper}>
-          {label && (
-            <label htmlFor={inputId} className={styles.label}>
-              {label}
-            </label>
-          )}
-          {status === 'modalError' && errorMessage && (
-            <span className={styles.topErrorMessage}>{errorMessage}</span>
+    return (
+      <div className={`${styles.wrapper} ${className || ''}`}>
+        {(label || status === 'modalError') && (
+          <div className={styles.labelWrapper}>
+            {label && (
+              <label htmlFor={inputId} className={styles.label}>
+                {label}
+              </label>
+            )}
+            {status === 'modalError' && errorMessage && (
+              <span className={styles.topErrorMessage}>{errorMessage}</span>
+            )}
+          </div>
+        )}
+
+        <div className={styles.inputContainer}>
+          <input
+            ref={ref}
+            id={inputId}
+            className={`${styles.input} ${inputStatusClass}`}
+            {...props}
+          />
+
+          {(status === 'error' || status === 'modalError') && (
+            <img src={ErrorIcon} alt="" className={styles.errorIcon} />
           )}
         </div>
-      )}
 
-      <div className={styles.inputContainer}>
-        <input
-          id={inputId}
-          className={`${styles.input} ${inputStatusClass}`}
-          {...props}
-        />
-
-        {(status === 'error' || status === 'modalError') && (
-          <img src={ErrorIcon} alt="" className={styles.errorIcon} />
-        )}
+        <div className={styles.errorWrap}>
+          {status === 'error' && errorMessage && (
+            <span className={styles.bottomErrorMessage}>{errorMessage}</span>
+          )}
+        </div>
       </div>
+    );
+  }
+);
 
-      <div className={styles.errorWrap}>
-        {status === 'error' && errorMessage && (
-          <span className={styles.bottomErrorMessage}>{errorMessage}</span>
-        )}
-      </div>
-    </div>
-  );
-}
+Input.displayName = 'Input';
+
+export default Input;

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -1,27 +1,68 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+
 import AuthLayout from '@/components/layout/AuthLayout';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
 import styles from './index.module.css';
 import KakaoIcon from '@/assets/icons/ic-kakao.svg';
 
+// 검사 규칙 생성
+const signinSchema = z.object({
+  email: z
+    .string()
+    .min(1, { message: '이메일은 필수 입력입니다.' })
+    .email({ message: '이메일 형식으로 작성해 주세요.' }),
+  password: z.string().min(1, { message: '비밀번호는 필수 입력입니다.' }),
+});
+
+// 생성한 스키마로 타입스크립트 타입 생성
+type SigninFormValues = z.infer<typeof signinSchema>;
+
 export default function Signin() {
+  // React Hook Form 세팅
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SigninFormValues>({
+    resolver: zodResolver(signinSchema),
+    mode: 'onBlur',
+  });
+
+  const onSubmit = (_data: SigninFormValues) => {
+    // TODO: API 호출
+  };
+
+  const handleKakaoLogin = () => {
+    // TODO: 카카오 소셜 로그인 연동
+  };
+
   return (
     <AuthLayout
       bottomText="계정이 없으신가요?"
       bottomLinkText="회원가입 하기"
       bottomLinkTo="/signup"
     >
-      <form className={styles.form}>
+      {/* 폼 제출 시 handleSubmit으로 검사한 뒤 통과 시에만 onSubmit 실행 */}
+      <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
         <div className={styles.inputGroup}>
           <Input
             label="이메일"
             type="email"
             placeholder="이메일을 입력해주세요"
+            {...register('email')}
+            status={errors.email ? 'error' : 'default'}
+            errorMessage={errors.email?.message}
           />
           <Input
             label="비밀번호"
             type="password"
             placeholder="비밀번호를 입력해주세요"
+            {...register('password')}
+            status={errors.password ? 'error' : 'default'}
+            errorMessage={errors.password?.message}
           />
         </div>
 
@@ -35,6 +76,7 @@ export default function Signin() {
             color="white"
             size="stretch"
             leftIcon={<img src={KakaoIcon} alt="카카오 로고" />}
+            onClick={handleKakaoLogin}
           >
             kakao로 시작하기
           </Button>

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -1,6 +1,6 @@
 import AuthLayout from '@/components/layout/AuthLayout';
 import Input from '@/components/common/Input';
-import Button from '@/components/common/button';
+import Button from '@/components/common/Button';
 import styles from './index.module.css';
 import KakaoIcon from '@/assets/icons/ic-kakao.svg';
 

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,6 +1,6 @@
 import AuthLayout from '@/components/layout/AuthLayout';
 import Input from '@/components/common/Input';
-import Button from '@/components/common/button';
+import Button from '@/components/common/Button';
 import styles from './index.module.css';
 
 export default function SignupPage() {

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,36 +1,96 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+
 import AuthLayout from '@/components/layout/AuthLayout';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
 import styles from './index.module.css';
 
+// 검사 규칙 생성
+const signupSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, { message: '이메일은 필수 입력입니다.' })
+      .email({ message: '이메일 형식으로 작성해 주세요.' }),
+    nickname: z
+      .string()
+      .min(1, { message: '닉네임은 필수 입력입니다.' })
+      .max(20, { message: '닉네임은 최대 20자까지 가능합니다.' }),
+    password: z
+      .string()
+      .min(1, { message: '비밀번호는 필수 입력입니다.' })
+      .min(8, { message: '비밀번호는 최소 8자 이상입니다.' })
+      .regex(/^[a-zA-Z0-9!@#$%^&*]+$/, {
+        message: '비밀번호는 숫자, 영문, 특수문자로만 가능합니다.',
+      }),
+    passwordConfirm: z
+      .string()
+      .min(1, { message: '비밀번호 확인을 입력해주세요.' }),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    path: ['passwordConfirm'],
+    message: '비밀번호가 일치하지 않습니다.',
+  });
+
+// 생성한 스키마로 타입스크립트 타입 생성
+type SignupFormValues = z.infer<typeof signupSchema>;
+
 export default function SignupPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignupFormValues>({
+    resolver: zodResolver(signupSchema),
+    mode: 'onBlur',
+  });
+
+  const onSubmit = (_data: SignupFormValues) => {
+    // TODO: 닉네임 중복 검사 및 API 호출
+  };
+
   return (
     <AuthLayout
       bottomText="계정이 이미 있으신가요?"
       bottomLinkText="로그인하기"
       bottomLinkTo="/signin"
     >
-      <form className={styles.form}>
+      {/* 폼 제출 시 handleSubmit으로 검사한 뒤 통과 시에만 onSubmit 실행 */}
+      <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
         <div className={styles.inputsGroup}>
           <Input
             label="이메일"
             type="email"
             placeholder="이메일을 입력해주세요"
+            {...register('email')}
+            status={errors.email ? 'error' : 'default'}
+            errorMessage={errors.email?.message}
           />
           <Input
             label="닉네임"
             type="text"
             placeholder="닉네임을 입력해주세요"
+            {...register('nickname')}
+            status={errors.nickname ? 'error' : 'default'}
+            errorMessage={errors.nickname?.message}
           />
           <Input
             label="비밀번호"
             type="password"
             placeholder="영문, 숫자, 특수문자(!@#$%^&*) 제한"
+            {...register('password')}
+            status={errors.password ? 'error' : 'default'}
+            errorMessage={errors.password?.message}
           />
           <Input
             label="비밀번호 확인"
             type="password"
             placeholder="비밀번호 확인"
+            {...register('passwordConfirm')}
+            status={errors.passwordConfirm ? 'error' : 'default'}
+            errorMessage={errors.passwordConfirm?.message}
           />
         </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #76 

## 📝작업 내용

> 로그인 및 회원가입 페이지의 입력값에 대한 유효성 검증 로직을 구현

### 스크린샷 (선택)
<img width="283" height="453" alt="image" src="https://github.com/user-attachments/assets/963892ee-b048-446f-a4ba-11d9737c5972" />
<img width="311" height="480" alt="image" src="https://github.com/user-attachments/assets/d413c664-4cf0-4ac6-bf44-6b83cc158e52" />

### 추가한 라이브러리
react-hook-form, zod, @hookform/resolvers

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
