### PR TITLE
[fix]: 와인 이미지 추가 시 이미지 잘림수정

### DIFF
--- a/src/components/common/ImgAddButton/index.module.css
+++ b/src/components/common/ImgAddButton/index.module.css
@@ -37,6 +37,9 @@
 }
 .preview {
   z-index: 9;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 .imgDelBtn {
   position: absolute;

--- a/src/storybook/img-add-btn/index.tsx
+++ b/src/storybook/img-add-btn/index.tsx
@@ -7,7 +7,7 @@ export default function ImageAddButton() {
     >
       <ImgAddButton />
       <ImgAddButton error />
-      <ImgAddButton src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTffxhzedoNtFe4C2NbDkgnfmgVNCIpw_7c5w&s" />
+      <ImgAddButton src="https://www.shinsegae-lnb.com/upload/product/wine/wine/images/G7%20%EA%B9%8C%EB%B2%A0%EB%A5%B4%EB%84%A4%20%EC%86%8C%EB%B9%84%EB%87%BD%20(%EB%B9%84%EA%B1%B4).jpg" />
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #97 

## 📝작업 내용

> 와인 이미지 추가 시, 이미지 잘림 수정

### 스크린샷 (선택)
<img width="249" height="104" alt="image" src="https://github.com/user-attachments/assets/4efb928c-1bff-43b8-8ac3-ae621e406610" />


### 추가한 라이브러리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
