### PR TITLE
Feat/#95/filter modal

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-VITE_API_BASE_URL=https://winereview-api.vercel.app/
-VITE_API_TEAM_BASE_URL=https://winereview-api.vercel.app/22-1
-# VITE_KAKAO_JS_KEY=

--- a/src/components/common/FilterTypeCheckbox/index.module.css
+++ b/src/components/common/FilterTypeCheckbox/index.module.css
@@ -34,7 +34,7 @@
 }
 
 /* 태블릿 및 모바일 */
-@media (max-width: 1024px) {
+@media (max-width: 1080px) {
   .typeWrap {
     flex-direction: row; /* 가로 정렬로 변경 */
     flex-wrap: wrap; /* 화면이 아주 좁아지면 다음 줄로 넘어가게 */

--- a/src/components/common/Modal/index.module.css
+++ b/src/components/common/Modal/index.module.css
@@ -15,6 +15,7 @@
   flex-direction: column;
   gap: 12px;
   max-width: 100%;
+  min-height: 0;
 }
 .container::after {
   content: '';
@@ -24,11 +25,6 @@
   bottom: 101px;
   height: 60px;
   pointer-events: none;
-  background: linear-gradient(
-    to top,
-    rgb(255, 255, 255) 0%,
-    rgba(255, 255, 255, 0) 100%
-  );
 }
 
 .button {
@@ -39,11 +35,11 @@
 .modalContent {
   width: 528px;
   max-width: 100%;
-  max-height: 1006px;
+  max-height: 90vh;
   display: flex;
   flex-direction: column;
   padding: 32px 24px 40px;
-  border-radius: 16px;
+  border-radius: 32px;
   background-color: #ffffff;
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
 }
@@ -65,7 +61,8 @@
 }
 
 .contentButton {
-  height: 50px;
+  min-height: 50px;
+  max-height: 110px;
   display: flex;
   align-items: center;
 }

--- a/src/components/common/PriceRangeSlider/index.tsx
+++ b/src/components/common/PriceRangeSlider/index.tsx
@@ -30,6 +30,7 @@ export default function PriceRangeSlider({
             style={{
               height: '6px',
               width: '100%',
+              position: 'relative',
               background: getTrackBackground({
                 values: value,
                 colors: [

--- a/src/components/list/WineAddModal/index.tsx
+++ b/src/components/list/WineAddModal/index.tsx
@@ -39,7 +39,7 @@ export default function WineAddModal() {
 
   return (
     <div>
-      <Button color="red" size="wineAddRed" onClick={() => setIsOpen(true)}>
+      <Button color="red" size="stretch" onClick={() => setIsOpen(true)}>
         와인 등록하기
       </Button>
 

--- a/src/components/list/WineFilter/index.module.css
+++ b/src/components/list/WineFilter/index.module.css
@@ -2,7 +2,8 @@
 .filterContainer {
   display: flex;
   flex-direction: column;
-  gap: 60px; /* 각 필터 그룹 사이의 간격 */
+  gap: 40px; /* 각 필터 그룹 사이의 간격 */
+  position: relative;
 }
 
 /* 필터 영역 */
@@ -10,6 +11,15 @@
   display: flex;
   flex-direction: column;
   gap: 20px; /* 제목과 필터 본문 사이의 간격 */
+
+  padding-bottom: 32px; /* 선과 내용 사이의 간격 */
+  border-bottom: 1px solid var(--color-gray-100);
+}
+
+/* 평점 영역은 선이 필요 없으므로 제거 */
+.filterSection:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
 }
 
 /* 필터 제목 */

--- a/src/components/list/WineFilter/index.tsx
+++ b/src/components/list/WineFilter/index.tsx
@@ -3,28 +3,28 @@ import PriceRangeSlider from '@/components/common/PriceRangeSlider';
 import FilterRatingCheckbox from '@/components/common/FilterRatingCheckbox';
 import styles from './index.module.css';
 import Button from '@/components/common/Button';
+import { useWineStore } from '@/store/useWineStore';
 
 interface WineFilterProps {
-  selectedTypes: string[]; // 선택된 와인 타입 리스트
-  setSelectedTypes: (types: string[]) => void; // 와인 타입 변경 핸들러
-  priceRange: number[]; // 최소 가격, 최대 가격 배열
-  setPriceRange: (range: number[]) => void; // 가격 범위 변경 핸들러
-  selectedRatings: string[]; // 선택된 평점 구간 리스트
-  setSelectedRatings: (ratings: string[]) => void; // 평점 선택 변경 핸들러
-  onApply: () => void; // 필터 적용하기 버튼 클릭 시 실행될 함수
+  onApply: () => void;
+  isModalMode?: boolean;
 }
 
-function WineFilter({
-  selectedTypes,
-  setSelectedTypes,
-  priceRange,
-  setPriceRange,
-  selectedRatings,
-  setSelectedRatings,
-  onApply,
-}: WineFilterProps) {
+function WineFilter({ onApply, isModalMode = false }: WineFilterProps) {
+  // 스토어에서 필요한 상태와 함수를 꺼내 씀.
+  const {
+    selectedTypes,
+    setSelectedTypes,
+    priceRange,
+    setPriceRange,
+    selectedRatings,
+    setSelectedRatings,
+  } = useWineStore();
+
   return (
-    <div className={styles.filterContainer}>
+    <div
+      className={`${styles.filterContainer} ${isModalMode ? styles.modalMode : ''}`}
+    >
       {/* 와인 타입 필터 */}
       <section className={styles.filterSection}>
         <h3 className={styles.filterTitle}>타입</h3>
@@ -46,12 +46,14 @@ function WineFilter({
         />
       </section>
 
-      {/* 필터 적용하기 버튼 */}
-      <div className={styles.buttonWrapper}>
-        <Button size="stretch" color="black" onClick={onApply}>
-          필터 적용하기
-        </Button>
-      </div>
+      {/* 모달 모드가 아닐 때(PC 버전)만 '필터 적용하기' 버튼을 보여줌 */}
+      {!isModalMode && (
+        <div className={styles.buttonWrapper}>
+          <Button size="stretch" color="black" onClick={onApply}>
+            필터 적용하기
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/list/WineFilterModal/index.module.css
+++ b/src/components/list/WineFilterModal/index.module.css
@@ -1,0 +1,16 @@
+/* 모달 버튼 영역 */
+.modalFooter {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  margin-top: 40px;
+}
+
+/* 필터 내용이 담기는 영역 */
+.modalMain {
+  position: relative;
+  height: auto;
+  width: 100%;
+  overflow: hidden; /* 스크롤 없앰 */
+}

--- a/src/components/list/WineFilterModal/index.tsx
+++ b/src/components/list/WineFilterModal/index.tsx
@@ -14,19 +14,26 @@ function WineFilterModal({ onApply }: WineFilterModalProps) {
   const [isOpen, setIsOpen] = useState(false);
   const { resetFilters } = useWineStore(); // zustand에서 초기화 함수 가져오기
 
-  // 모달 오픈 시 뒷배경 스크롤 방지
+  // 모달 오픈 시 뒷배경 스크롤 차단하는 로직
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
+    // 모달이 열리지 않은 상태
+    if (!isOpen) {
+      return;
     }
 
-    // 컴포넌트가 언마운트될 때 혹시 모르니 스크롤을 다시 풀어줌.
+    // 현재 브라우저의 body에 적용된 스타일(overflow) 값을 저장함.
+    // 모달을 닫을 때, 원래 상태로 복구하기 위함.
+    const originalOverflow = window.getComputedStyle(document.body).overflow;
+
+    // 모달이 떴으니 뒷배경이 움직이지 않게 스크롤 차단
+    document.body.style.overflow = 'hidden';
+
+    // Clean-up 함수: 모달이 닫히거나 컴포넌트가 언마운트될 때 실행됨.
     return () => {
-      document.body.style.overflow = 'unset';
+      // 저장해뒀던 원래 상태로 돌려놓음.
+      document.body.style.overflow = originalOverflow;
     };
-  }, [isOpen]);
+  }, [isOpen]); // 모달의 열림,닫힘 상태가 변할 때마다 과정 반복
 
   // 필터 적용 버튼 핸들러
   const handleApply = () => {

--- a/src/components/list/WineFilterModal/index.tsx
+++ b/src/components/list/WineFilterModal/index.tsx
@@ -1,0 +1,79 @@
+import Button from '@/components/common/Button';
+import FilterIcon from '@/assets/icons/ic-filter.svg';
+import { useEffect, useState } from 'react';
+import { useWineStore } from '@/store/useWineStore';
+import styles from './index.module.css';
+import Modal from '@/components/common/Modal';
+import WineFilter from '../WineFilter';
+
+interface WineFilterModalProps {
+  onApply: () => void; // 필터 적용 시 서버 데이터를 다시 불러오는 함수
+}
+
+function WineFilterModal({ onApply }: WineFilterModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { resetFilters } = useWineStore(); // zustand에서 초기화 함수 가져오기
+
+  // 모달 오픈 시 뒷배경 스크롤 방지
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    // 컴포넌트가 언마운트될 때 혹시 모르니 스크롤을 다시 풀어줌.
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  // 필터 적용 버튼 핸들러
+  const handleApply = () => {
+    onApply(); // 부모(WinesList)의 데이터 페칭 함수 실행
+    setIsOpen(false); // 모달 닫기
+  };
+
+  // 초기화 버튼 핸들러
+  const handleReset = () => {
+    resetFilters(); // 필터 상태 리셋
+  };
+
+  const modalFooter = (
+    <div className={styles.modalFooter}>
+      <Button color="black" size="stretch" onClick={handleApply}>
+        필터 적용하기
+      </Button>
+      <Button color="white" size="stretch" onClick={handleReset}>
+        초기화
+      </Button>
+    </div>
+  );
+
+  return (
+    <>
+      {/* 태블릿/모바일에서 보일 필터 버튼 */}
+      <Button
+        color="pureLine"
+        size="iconBtn"
+        onClick={() => setIsOpen(true)}
+        leftIcon={<img src={FilterIcon} alt="필터 아이콘" />}
+      />
+
+      {/* 필터 모달 */}
+      <Modal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="필터"
+        footer={modalFooter}
+      >
+        <div className={styles.modalMain}>
+          {/* isModalMode={true}를 줘서 내부의 중복된 '필터 적용하기' 버튼을 숨김. */}
+          <WineFilter onApply={handleApply} isModalMode={true} />
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+export default WineFilterModal;

--- a/src/components/list/WineListCard/index.module.css
+++ b/src/components/list/WineListCard/index.module.css
@@ -7,11 +7,6 @@
   width: 370px;
 }
 
-.cardContainer:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
-}
-
 /* 이미지 영역 */
 .imageWrapper {
   position: relative;

--- a/src/components/list/WineListGrid/index.module.css
+++ b/src/components/list/WineListGrid/index.module.css
@@ -1,26 +1,25 @@
 .gridContainer {
   display: grid;
-  grid-template-columns: repeat(2, 1fr); /* 2열 */
+  grid-template-columns: repeat(2, 370px); /* 2열 */
   column-gap: 52px; /* 좌우 간격 */
   row-gap: 48px; /* 상하 간격 */
   width: 100%;
+  justify-content: center;
 }
 
 /* 태블릿 */
 @media (max-width: 1080px) {
   .gridContainer {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(2, 370px);
     column-gap: 24px; /* 좌우 간격 */
     row-gap: 48px; /* 상하 간격 */
-    justify-content: center;
-    margin: 0 auto;
   }
 }
 
 /* 모바일 */
 @media (max-width: 767px) {
   .gridContainer {
-    grid-template-columns: 1fr; /* 1열 */
+    grid-template-columns: 370px; /* 1열 */
     row-gap: 48px; /* 상하 간격 */
   }
 }

--- a/src/components/list/WineListGrid/index.module.css
+++ b/src/components/list/WineListGrid/index.module.css
@@ -9,8 +9,11 @@
 /* 태블릿 */
 @media (max-width: 1080px) {
   .gridContainer {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     column-gap: 24px; /* 좌우 간격 */
     row-gap: 48px; /* 상하 간격 */
+    justify-content: center;
+    margin: 0 auto;
   }
 }
 

--- a/src/pages/WinesList/index.module.css
+++ b/src/pages/WinesList/index.module.css
@@ -1,16 +1,22 @@
+/* 슬라이더 영역 */
+.sliderContent {
+  width: 100%;
+  height: 470px;
+  background-color: #f5f5f5; /* 영역 확인용 임시 색상 */
+}
+
 /* 메인 레이아웃 (좌우 배치) */
 .mainContent {
   display: flex;
-  gap: 48px; /* 필터, 우측 콘텐츠 간격 */
-  margin-top: 540px;
-  margin-left: 360px;
-  margin-right: 360px;
+  gap: 48px; /* 좌측, 우측 콘텐츠 간격 */
+  margin: 64px 360px 0;
 }
 
 /* 좌측 필터 고정폭 */
 .filterAside {
   width: 360px;
   flex-shrink: 0;
+  display: block; /* PC에서는 보임 */
 }
 
 /* 우측 영역 (검색창 + 그리드) */
@@ -18,17 +24,49 @@
   flex-grow: 1; /* 남은 공간 모두 차지 */
   display: flex;
   flex-direction: column;
-  gap: 64px; /* 검색창과 그리드 사이의 세로 간격 */
+  gap: 64px; /* 검색창과 그리드 사이 간격 */
 }
 
-/* 검색창 */
-.searchSection {
-  width: 100%;
+/* PC에서는 모바일 전용 버튼 영역을 숨김. */
+.mobileActionButtons {
+  display: none;
 }
 
-/* 그리드 리스트 */
-.listSection {
-  width: 100%;
+/* 태블릿 */
+@media (max-width: 1080px) {
+  .mainContent {
+    flex-direction: column;
+    margin: 40px 20px 0;
+    gap: 114px;
+  }
+
+  .filterAside {
+    display: none; /* 사이드바 필터 숨김 */
+  }
+
+  .contentRight {
+    display: flex;
+    flex-direction: column;
+    /* 전체적으로 위에서 아래로 흐르게 하고, gap으로 사이 간격을 조절하세요 */
+    gap: 32px;
+  }
+
+  .searchSection {
+    width: 100%;
+  }
+
+  /* 💡 시안처럼 검색창 아래 버튼들을 나란히 배치 */
+  .mobileActionButtons {
+    display: flex;
+    justify-content: space-between; /* 필터(좌) / 등록(우) 양끝 정렬 */
+    align-items: center;
+    margin-top: 10px; /* 검색창과의 간격 */
+    width: 100%;
+  }
+
+  .mobileAddModal {
+    flex-shrink: 0;
+  }
 }
 
 .filterWrapper {

--- a/src/pages/WinesList/index.module.css
+++ b/src/pages/WinesList/index.module.css
@@ -31,7 +31,7 @@
   width: 100%;
 }
 
-.filterPlaceholder {
+.filterWrapper {
   height: 600px;
   padding: 20px;
 }
@@ -39,4 +39,8 @@
 .loading {
   text-align: center;
   padding: 100px 0;
+}
+
+.addModalWrapper {
+  margin-top: 20px;
 }

--- a/src/pages/WinesList/index.tsx
+++ b/src/pages/WinesList/index.tsx
@@ -1,20 +1,28 @@
 import { useEffect, useState } from 'react';
 import { getWines, type GetWinesParams } from '@/apis/wine';
+import { useWineStore } from '@/store/useWineStore';
 import WineListGrid, { type Wine } from '@/components/list/WineListGrid';
 import SearchBar from '@/components/common/SearchBar';
 import WineFilter from '@/components/list/WineFilter';
-import styles from './index.module.css';
 import WineAddModal from '@/components/list/WineAddModal';
+import styles from './index.module.css';
 
 function WinesList() {
+  // 기존 useState들을 지우고 Zustand 스토어에서 상태와 함수를 가져옴.
+  const {
+    keyword,
+    setKeyword,
+    selectedTypes,
+    setSelectedTypes,
+    priceRange,
+    setPriceRange,
+    selectedRatings,
+    setSelectedRatings,
+  } = useWineStore();
+
+  // 리스트 데이터와 로딩 상태는 이 페이지에서만 쓰이므로 useState로 남겨둠.
   const [wines, setWines] = useState<Wine[]>([]); // 화면에 보여줄 와인 목록 상태
   const [isLoading, setIsLoading] = useState(true); // 로딩 상태
-  const [keyword, setKeyword] = useState(''); // 사용자가 입력 창에 타이핑하는 글자 상태
-
-  // 필터 관련 상태들
-  const [selectedTypes, setSelectedTypes] = useState<string[]>([]); // 선택된 와인 타입
-  const [priceRange, setPriceRange] = useState<number[]>([0, 1000000]); // 가격 슬라이더 범위 [최소, 최대]
-  const [selectedRatings, setSelectedRatings] = useState<string[]>(['전체']); // 선택된 평점 구간
 
   // 데이터를 가져오고 필터링하는 공통 함수
   const fetchWinesData = async () => {
@@ -96,8 +104,7 @@ function WinesList() {
       <div className={styles.mainContent}>
         {/* 좌측 필터 영역 */}
         <aside className={styles.filterAside}>
-          <div className={styles.filterPlaceholder}>
-
+          <div className={styles.filterWrapper}>
             {/* 조립한 필터 컴포넌트에 상태 전달 */}
             <WineFilter
               selectedTypes={selectedTypes}
@@ -108,7 +115,9 @@ function WinesList() {
               setSelectedRatings={setSelectedRatings}
               onApply={handleApplyFilters}
             />
-            <WineAddModal />
+            <div className={styles.addModalWrapper}>
+              <WineAddModal />
+            </div>
           </div>
         </aside>
 

--- a/src/pages/WinesList/index.tsx
+++ b/src/pages/WinesList/index.tsx
@@ -6,6 +6,7 @@ import SearchBar from '@/components/common/SearchBar';
 import WineFilter from '@/components/list/WineFilter';
 import WineAddModal from '@/components/list/WineAddModal';
 import styles from './index.module.css';
+import WineFilterModal from '@/components/list/WineFilterModal';
 
 function WinesList() {
   // 기존 useState들을 지우고 Zustand 스토어에서 상태와 함수를 가져옴.
@@ -96,7 +97,7 @@ function WinesList() {
   return (
     <div className={styles.container}>
       {/* 수정님이 만드실 슬라이더 영역 */}
-      <section className={styles.sliderPlaceholder}>
+      <section className={styles.sliderContent}>
         {/* 여기에 와인 슬라이더가 들어올 예정 */}
       </section>
 
@@ -106,15 +107,7 @@ function WinesList() {
         <aside className={styles.filterAside}>
           <div className={styles.filterWrapper}>
             {/* 조립한 필터 컴포넌트에 상태 전달 */}
-            <WineFilter
-              selectedTypes={selectedTypes}
-              setSelectedTypes={setSelectedTypes}
-              priceRange={priceRange}
-              setPriceRange={setPriceRange}
-              selectedRatings={selectedRatings}
-              setSelectedRatings={setSelectedRatings}
-              onApply={handleApplyFilters}
-            />
+            <WineFilter onApply={handleApplyFilters} />
             <div className={styles.addModalWrapper}>
               <WineAddModal />
             </div>
@@ -131,6 +124,16 @@ function WinesList() {
               onSearchSubmit={handleApplyFilters}
             />
           </section>
+
+          {/* 태블릿/모바일 전용 버튼 영역 추가 */}
+          <div className={styles.mobileActionButtons}>
+            <WineFilterModal onApply={handleApplyFilters} />
+
+            {/* 와인 등록 버튼 (모바일용 위치) */}
+            <div className={styles.mobileAddModal}>
+              <WineAddModal />
+            </div>
+          </div>
 
           {/* 리스트 영역 */}
           <main className={styles.listSection}>

--- a/src/store/useWineStore.ts
+++ b/src/store/useWineStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+
+// 와인 필터와 관련된 상태들의 타입 정의
+interface WineFilterState {
+  keyword: string; // 이름 검색어
+  selectedTypes: string[]; // 선택된 와인 타입 리스트
+  priceRange: number[]; // 가격 슬라이더 범위 [최소, 최대]
+  selectedRatings: string[]; // 선택된 평점 구간 리스트
+
+  // 상태를 변경하는 함수들
+  setKeyword: (keyword: string) => void;
+  setSelectedTypes: (types: string[]) => void;
+  setPriceRange: (range: number[]) => void;
+  setSelectedRatings: (ratings: string[]) => void;
+  resetFilters: () => void; // 태블릿/모바일 필터 모달의 초기화 버튼용
+}
+
+export const useWineStore = create<WineFilterState>((set) => ({
+  // 초기값 설정
+  keyword: '',
+  selectedTypes: [],
+  priceRange: [0, 1000000],
+  selectedRatings: ['전체'],
+
+  // 상태 업데이트 로직 : 개별 필터 변경 시 호출
+  setKeyword: (keyword) => set({ keyword }),
+  setSelectedTypes: (selectedTypes) => set({ selectedTypes }),
+  setPriceRange: (priceRange) => set({ priceRange }),
+  setSelectedRatings: (selectedRatings) => set({ selectedRatings }),
+
+  // 필터 초기화 : 모든 필터 상태를 리셋
+  resetFilters: () =>
+    set({
+      keyword: '',
+      selectedTypes: [],
+      priceRange: [0, 1000000],
+      selectedRatings: ['전체'],
+    }),
+}));

--- a/src/store/useWineStore.ts
+++ b/src/store/useWineStore.ts
@@ -31,7 +31,6 @@ export const useWineStore = create<WineFilterState>((set) => ({
   // 필터 초기화 : 모든 필터 상태를 리셋
   resetFilters: () =>
     set({
-      keyword: '',
       selectedTypes: [],
       priceRange: [0, 1000000],
       selectedRatings: ['전체'],


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #95 

## 📝작업 내용

- 태블릿, 모바일 크기에서만 보이는 필터 모달 구현
- 와인 리스트 반응형 UI 구현
> 와인 등록하기 버튼의 스타일은 수정님 코드와 합쳤을 때 수정할 것임.

### 스크린샷 (선택)
태블릿
<img width="1104" height="895" alt="image" src="https://github.com/user-attachments/assets/5329fb07-a0e2-44ab-9c71-f4135463bf1f" />
모바일
<img width="786" height="895" alt="image" src="https://github.com/user-attachments/assets/251cdac6-e298-42e6-8396-e0a121004ca7" />
태블릿 - 필터 모달
<img width="1100" height="896" alt="image" src="https://github.com/user-attachments/assets/7a41d409-7378-484f-bc80-25e768bb6d03" />
모바일 - 필터 모달
<img width="788" height="897" alt="image" src="https://github.com/user-attachments/assets/a914d4ee-72cd-4e5a-bce2-64aa1f92a9eb" />


### 추가한 라이브러리
> 없음.
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
